### PR TITLE
Add several types of commands to the request command struct.

### DIFF
--- a/command.go
+++ b/command.go
@@ -17,7 +17,17 @@ type CommandRequest struct {
 	AccountConfiguration
 	ScheduleOSUpdateScan
 	InstallProfile
+	RemoveProfile
+	InstallProvisioningProfile
+	RemoveProvisioningProfile
 	InstalledApplicationList
+	DeviceLock
+	ClearPasscode
+	EraseDevice
+	RequestMirroring
+	Restrictions
+	DeleteUser
+	EnableLostMode
 }
 
 // Payload is an MDM payload
@@ -241,7 +251,8 @@ func NewPayload(request *CommandRequest) (*Payload, error) {
 		"ManagedMediaList",
 		"OSUpdateStatus",
 		"DeviceConfigured",
-		"AvailableOSUpdates":
+		"AvailableOSUpdates",
+		"Restrictions":
 		return payload, nil
 	case "InstallApplication":
 		payload.Command.InstallApplication = request.InstallApplication


### PR DESCRIPTION
Add `Restrictions` as a valid payload-less command.
More command types are available as requests, even though they may fail at the moment.
