### PR TITLE
Changed the download size type from float to int

### DIFF
--- a/response.go
+++ b/response.go
@@ -28,7 +28,7 @@ type AvailableOSUpdatesResponseItem struct {
 	ProductName       string  `json:"product_name"`
 	Version           string  `json:"version"`
 	Build             string  `json:"build"`
-	DownloadSize      float64 `json:"download_size"`
+	DownloadSize      int `json:"download_size"`
 	InstallSize       float64 `json:"install_size"`
 
 	// Each entry represents an app identifier that is closed to install this update (macOS only).


### PR DESCRIPTION
When requesting the device to list AvailableOSUpdates, MicroMDM fails to parse the response from the device due to a unmarshaling error, ref micromdm/micromdm#368.

MacOS does not send the DownloadSize attribute, but iOS send it as an inteter, not a float. 

I have successfully testet this. After changing the type from float to integer, the MDM was able to parse the command response.

```
transport=http method=PUT status=200 proto=HTTP/1.1 host=51.175.81.54 user_agent=MDM/1.0 path=/mdm/connect
<dict>
        <key>AvailableOSUpdates</key>
        <array>
                <dict>
                        <key>AllowsInstallLater</key>
                        <false/>
                        <key>Build</key>
                        <string>15D100</string>
                        <key>DownloadSize</key>
                        <integer>1174014135</integer>
                        <key>HumanReadableName</key>
                        <string>iOS 11</string>
                        <key>ProductKey</key>
                        <string>iOSUpdate15D100</string>
                        <key>ProductName</key>
                        <string>iOS</string>
                        <key>RestartRequired</key>
                        <true/>
                        <key>Version</key>
                        <string>11.2.6</string>
                </dict>
        </array>
        <key>CommandUUID</key>
        <string>ecbe2abd-c2a3-4baf-bc7e-3f6030f4602e</string>
        <key>Status</key>
        <string>Acknowledged</string>
        <key>UDID</key>
        <string>7c31b3a19a1aa12de8a974cb69cb7511e1c1fd7e</string>
</dict>
</plist>

---END Request---
level=info component=connect method=Acknowledge udid=7c31b3a19a0aa12de8b97fcb69cb7531e1c1fd7e command_uuid=ecae5abd-c2a3-4bff-bb7e-2f6030f4602e status=Acknowledged request_type= err=null took=2.146896ms
``` 